### PR TITLE
Add Boids-inspired iterative registration option

### DIFF
--- a/VoxelMorph-torch-master/Model/boids.py
+++ b/VoxelMorph-torch-master/Model/boids.py
@@ -1,0 +1,52 @@
+import torch
+import torch.nn as nn
+from .model import SpatialTransformer
+from . import losses
+
+
+class WeightNet(nn.Module):
+    """Lightweight network predicting spatially varying weights."""
+
+    def __init__(self, in_channels=2, hidden=16):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv3d(in_channels, hidden, kernel_size=3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv3d(hidden, 3, kernel_size=1),
+            nn.Softplus()
+        )
+
+    def forward(self, x):
+        w = self.net(x)
+        return torch.chunk(w, 3, dim=1)
+
+
+class BoidsRegister(nn.Module):
+    """VoxelMorph variant using Boids-inspired iterative updates."""
+
+    def __init__(self, vol_size, in_channels=2, steps=5, step_size=1.0, weight_net=None):
+        super().__init__()
+        self.transformer = SpatialTransformer(vol_size)
+        self.steps = steps
+        self.step_size = step_size
+        self.weight_net = weight_net or WeightNet(in_channels)
+
+    def forward(self, moving, fixed):
+        batch = moving.shape[0]
+        device = moving.device
+        v = torch.zeros(batch, 3, *moving.shape[2:], device=device, requires_grad=True)
+        features = torch.cat([moving, fixed], dim=1)
+        alpha, beta, gamma = self.weight_net(features)
+        for _ in range(self.steps):
+            v.requires_grad_(True)
+            warped = self.transformer(moving, v)
+            sim_loss = losses.ncc_loss(warped, fixed)
+            F_data = -torch.autograd.grad(sim_loss, v, create_graph=True)[0]
+            align_loss = losses.gradient_loss(v)
+            F_align = -torch.autograd.grad(align_loss, v, create_graph=True)[0]
+            jac_loss = losses.NJ_loss(v)
+            F_sep = -torch.autograd.grad(jac_loss, v, create_graph=True)[0]
+            update = alpha * F_data + beta * F_align + gamma * F_sep
+            v = v + self.step_size * update
+        warped = self.transformer(moving, v)
+        return warped, v

--- a/VoxelMorph-torch-master/Model/config.py
+++ b/VoxelMorph-torch-master/Model/config.py
@@ -3,41 +3,27 @@ import argparse
 parser = argparse.ArgumentParser()
 
 # 公共参数
-parser.add_argument("--gpu", type=str, help="gpu id",
-                    dest="gpu", default='0')
-parser.add_argument("--atlas_file", type=str, help="gpu id number",
-                    dest="atlas_file", default='LPBA40/fixed.nii.gz')
-parser.add_argument("--model", type=str, help="voxelmorph 1 or 2",
-                    dest="model", choices=['vm1', 'vm2'], default='vm2')
-parser.add_argument("--result_dir", type=str, help="results folder",
-                    dest="result_dir", default='./Result')
+parser.add_argument("--gpu", type=str, help="gpu id", dest="gpu", default='0')
+parser.add_argument("--atlas_file", type=str, help="gpu id number", dest="atlas_file", default='LPBA40/fixed.nii.gz')
+parser.add_argument("--model", type=str, help="voxelmorph 1 or 2", dest="model", choices=['vm1', 'vm2'], default='vm2')
+parser.add_argument("--result_dir", type=str, help="results folder", dest="result_dir", default='./Result')
 
 # train时参数
-parser.add_argument("--train_dir", type=str, help="data folder with training vols",
-                    dest="train_dir", default="LPBA40/train")
-parser.add_argument("--lr", type=float, help="learning rate",
-                    dest="lr", default=4e-4)
-parser.add_argument("--n_iter", type=int, help="number of iterations",
-                    dest="n_iter", default=15000)
-parser.add_argument("--sim_loss", type=str, help="image similarity loss: mse or ncc",
-                    dest="sim_loss", default='ncc')
-parser.add_argument("--alpha", type=float, help="regularization parameter",
-                    dest="alpha", default=4.0)  # recommend 1.0 for ncc, 0.01 for mse
-parser.add_argument("--batch_size", type=int, help="batch_size",
-                    dest="batch_size", default=1)
-parser.add_argument("--n_save_iter", type=int, help="frequency of model saves",
-                    dest="n_save_iter", default=1000)
-parser.add_argument("--model_dir", type=str, help="models folder",
-                    dest="model_dir", default='./Checkpoint')
-parser.add_argument("--log_dir", type=str, help="logs folder",
-                    dest="log_dir", default='./Log')
+parser.add_argument("--train_dir", type=str, help="data folder with training vols", dest="train_dir", default="LPBA40/train")
+parser.add_argument("--lr", type=float, help="learning rate", dest="lr", default=4e-4)
+parser.add_argument("--n_iter", type=int, help="number of iterations", dest="n_iter", default=15000)
+parser.add_argument("--sim_loss", type=str, help="image similarity loss: mse or ncc", dest="sim_loss", default='ncc')
+parser.add_argument("--alpha", type=float, help="regularization parameter", dest="alpha", default=4.0)
+parser.add_argument("--batch_size", type=int, help="batch_size", dest="batch_size", default=1)
+parser.add_argument("--n_save_iter", type=int, help="frequency of model saves", dest="n_save_iter", default=1000)
+parser.add_argument("--model_dir", type=str, help="models folder", dest="model_dir", default='./Checkpoint')
+parser.add_argument("--log_dir", type=str, help="logs folder", dest="log_dir", default='./Log')
+parser.add_argument("--use_boids", action="store_true", help="use Boids-based iterative registration")
+parser.add_argument("--boids_steps", type=int, dest="boids_steps", default=5, help="number of Boids update steps")
 
 # test时参数
-parser.add_argument("--test_dir", type=str, help="test data directory",
-                    dest="test_dir", default='LPBA40/test')
-parser.add_argument("--label_dir", type=str, help="label data directory",
-                    dest="label_dir", default='LPBA40/label')
-parser.add_argument("--checkpoint_path", type=str, help="model weight file",
-                    dest="checkpoint_path", default="./Checkpoint/LPBA40.pth")
+parser.add_argument("--test_dir", type=str, help="test data directory", dest="test_dir", default='LPBA40/test')
+parser.add_argument("--label_dir", type=str, help="label data directory", dest="label_dir", default='LPBA40/label')
+parser.add_argument("--checkpoint_path", type=str, help="model weight file", dest="checkpoint_path", default="./Checkpoint/LPBA40.pth")
 
 args = parser.parse_args()

--- a/VoxelMorph-torch-master/test.py
+++ b/VoxelMorph-torch-master/test.py
@@ -10,6 +10,7 @@ import SimpleITK as sitk
 from Model import losses
 from Model.config import args
 from Model.model import U_Network, SpatialTransformer
+from Model.boids import BoidsRegister
 
 
 def make_dirs():
@@ -55,18 +56,24 @@ def test():
 
     # Prepare the vm1 or vm2 model and send to device
     nf_enc = [16, 32, 32, 32]
-    if args.model == "vm1":
-        nf_dec = [32, 32, 32, 32, 8, 8]
+    if args.use_boids:
+        model = BoidsRegister(vol_size, steps=args.boids_steps).to(device)
+        model.load_state_dict(torch.load(args.checkpoint_path))
+        model.eval()
+        STN_label = SpatialTransformer(vol_size, mode="nearest").to(device)
+        STN_label.eval()
     else:
-        nf_dec = [32, 32, 32, 32, 32, 16, 16]
-    # Set up model
-    UNet = U_Network(len(vol_size), nf_enc, nf_dec).to(device)
-    UNet.load_state_dict(torch.load(args.checkpoint_path))
-    STN_img = SpatialTransformer(vol_size).to(device)
-    STN_label = SpatialTransformer(vol_size, mode="nearest").to(device)
-    UNet.eval()
-    STN_img.eval()
-    STN_label.eval()
+        if args.model == "vm1":
+            nf_dec = [32, 32, 32, 32, 8, 8]
+        else:
+            nf_dec = [32, 32, 32, 32, 32, 16, 16]
+        model = U_Network(len(vol_size), nf_enc, nf_dec).to(device)
+        model.load_state_dict(torch.load(args.checkpoint_path))
+        STN_img = SpatialTransformer(vol_size).to(device)
+        STN_label = SpatialTransformer(vol_size, mode="nearest").to(device)
+        model.eval()
+        STN_img.eval()
+        STN_label.eval()
 
     DSC = []
     # fixed图像对应的label
@@ -82,8 +89,11 @@ def test():
         input_label = torch.from_numpy(input_label).to(device).float()
 
         # 获得配准后的图像和label
-        pred_flow = UNet(input_moving, input_fixed)
-        pred_img = STN_img(input_moving, pred_flow)
+        if args.use_boids:
+            pred_img, pred_flow = model(input_moving, input_fixed)
+        else:
+            pred_flow = model(input_moving, input_fixed)
+            pred_img = STN_img(input_moving, pred_flow)
         pred_label = STN_label(input_label, pred_flow)
 
         # 计算DSC

--- a/VoxelMorph-torch-master/train.py
+++ b/VoxelMorph-torch-master/train.py
@@ -13,6 +13,7 @@ from Model import losses
 from Model.config import args
 from Model.datagenerators import Dataset
 from Model.model import U_Network, SpatialTransformer
+from Model.boids import BoidsRegister
 
 
 def count_parameters(model):
@@ -56,22 +57,26 @@ def train():
     input_fixed = np.repeat(input_fixed, args.batch_size, axis=0)
     input_fixed = torch.from_numpy(input_fixed).to(device).float()
 
-    # 创建配准网络（UNet）和STN
+    # 创建配准网络
     nf_enc = [16, 32, 32, 32]
-    if args.model == "vm1":
-        nf_dec = [32, 32, 32, 32, 8, 8]
+    if args.use_boids:
+        reg_model = BoidsRegister(vol_size, steps=args.boids_steps).to(device)
+        reg_model.train()
+        print("BoidsRegister: ", count_parameters(reg_model))
     else:
-        nf_dec = [32, 32, 32, 32, 32, 16, 16]
-    UNet = U_Network(len(vol_size), nf_enc, nf_dec).to(device)
-    STN = SpatialTransformer(vol_size).to(device)
-    UNet.train()
-    STN.train()
-    # 模型参数个数
-    print("UNet: ", count_parameters(UNet))
-    print("STN: ", count_parameters(STN))
+        if args.model == "vm1":
+            nf_dec = [32, 32, 32, 32, 8, 8]
+        else:
+            nf_dec = [32, 32, 32, 32, 32, 16, 16]
+        reg_model = U_Network(len(vol_size), nf_enc, nf_dec).to(device)
+        stn = SpatialTransformer(vol_size).to(device)
+        reg_model.train()
+        stn.train()
+        print("UNet: ", count_parameters(reg_model))
+        print("STN: ", count_parameters(stn))
 
     # Set optimizer and losses
-    opt = Adam(UNet.parameters(), lr=args.lr)
+    opt = Adam(reg_model.parameters(), lr=args.lr)
     sim_loss_fn = losses.ncc_loss if args.sim_loss == "ncc" else losses.mse_loss
     grad_loss_fn = losses.gradient_loss
 
@@ -94,8 +99,11 @@ def train():
         input_moving = input_moving.to(device).float()
 
         # Run the data through the model to produce warp and flow field
-        flow_m2f = UNet(input_moving, input_fixed)
-        m2f = STN(input_moving, flow_m2f)
+        if args.use_boids:
+            m2f, flow_m2f = reg_model(input_moving, input_fixed)
+        else:
+            flow_m2f = reg_model(input_moving, input_fixed)
+            m2f = stn(input_moving, flow_m2f)
 
         # Calculate loss
         sim_loss = sim_loss_fn(m2f, input_fixed)
@@ -112,7 +120,7 @@ def train():
         if i % args.n_save_iter == 0:
             # Save model checkpoint
             save_file_name = os.path.join(args.model_dir, '%d.pth' % i)
-            torch.save(UNet.state_dict(), save_file_name)
+            torch.save(reg_model.state_dict(), save_file_name)
             # Save images
             m_name = str(i) + "_m.nii.gz"
             m2f_name = str(i) + "_m2f.nii.gz"


### PR DESCRIPTION
## Summary
- Introduce BoidsRegister module implementing Boids-inspired iterative SVF updates with learned weights
- Add `--use_boids` and `--boids_steps` flags to enable the Boids workflow
- Update training and testing scripts to optionally run the Boids-based registration path

## Testing
- `pytest`
- `python train.py --use_boids --n_iter 1` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68b5407289b08331ada36601d9b5d60b